### PR TITLE
Add Jest test for save and load state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/game.test.js
+++ b/game.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('saveSlot and loadSlot', () => {
+  let context;
+
+  beforeEach(() => {
+    // clear storage
+    localStorage.clear();
+    // extract functions from game.js
+    const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+    const saveSlotCode = code.match(/function saveSlot\(\)\{[\s\S]*?\}/)[0];
+    const loadSlotCode = code.match(/function loadSlot\(\)\{[\s\S]*?\}/)[0];
+
+    context = {
+      localStorage: global.localStorage,
+      updHUD: () => {},
+      resetWorld: () => {}
+    };
+    vm.createContext(context);
+    vm.runInContext(`
+      var lvl=1, goal=25, goalCaught=0;
+      var countL=0, countM=0, countY=0;
+      ${saveSlotCode}
+      ${loadSlotCode}
+    `, context);
+  });
+
+  test('restores game state after save/load', () => {
+    Object.assign(context, { lvl: 3, goal: 100, goalCaught: 50, countL: 1, countM: 2, countY: 3 });
+    context.saveSlot();
+
+    Object.assign(context, { lvl: 0, goal: 0, goalCaught: 0, countL: 0, countM: 0, countY: 0 });
+    const result = context.loadSlot();
+
+    expect(result).toBe(true);
+    const { lvl, goal, goalCaught, countL, countM, countY } = context;
+    expect({ lvl, goal, goalCaught, countL, countM, countY }).toEqual({
+      lvl: 3,
+      goal: 100,
+      goalCaught: 50,
+      countL: 1,
+      countM: 2,
+      countY: 3
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "loki-maeusejagd",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest setup for testing
- test saveSlot/loadSlot restore game state via localStorage

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b41d6fcd083269912b23744d28442