### PR TITLE
Fix sprint sound lookup and win message string

### DIFF
--- a/game.js
+++ b/game.js
@@ -17,7 +17,7 @@
   const mm = document.getElementById('minimap'), mctx = mm.getContext('2d');
   const ovWin=document.getElementById('ovWin'), winMsg=document.getElementById('winMsg'), btnNext=document.getElementById('btnNext');
   const ovLose=document.getElementById('ovLose'), loseMsg=document.getElementById('loseMsg'), btnRetry=document.getElementById('btnRetry');
-  const bgm = document.getElementById('bgm'); const sCatch=document.getElementById('sCatch'), sPounce=document.getElementById('sPounce'), sSprint=document.getElementById('sprint');
+  const bgm = document.getElementById('bgm'); const sCatch=document.getElementById('sCatch'), sPounce=document.getElementById('sPounce'), sSprint=document.getElementById('sSprint');
 
   let state='menu',lvl=1,goal=25,goalCaught=0;
   let countL=0,countM=0,countY=0;
@@ -206,7 +206,7 @@
     });
 
     if(countM>=goal || countY>=goal){ document.getElementById('ovLose').style.display='flex'; document.getElementById('loseMsg').textContent=(countM>=goal?'Merlin':'Yumi')+' war schneller!'; scene.scene.pause(); return; }
-    if(goalCaught>=goal){ document.getElementById('ovWin').style.display='flex'; document.getElementById('winMsg').textContent='Weiter geht\\'s!'; scene.scene.pause(); }
+    if(goalCaught>=goal){ document.getElementById('ovWin').style.display='flex'; document.getElementById('winMsg').textContent="Weiter geht's!"; scene.scene.pause(); }
 
     const cam=scene.cameras.main;
     layers.bg.tilePositionX=cam.scrollX*0.5; layers.bg.tilePositionY=cam.scrollY*0.5;


### PR DESCRIPTION
## Summary
- Correct sprint sound element ID reference
- Replace improperly escaped win message with a clean string literal

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b40a98fd88326aa05a6311bc006a1