### PR TITLE
Add sprint boost controls and speed up Loki

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,7 +78,7 @@
     }
 
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=360; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=480; loki.boost=0;
     miceGroup = scene.physics.add.group({ allowGravity:false });
     for(let i=0;i<26;i++) spawnMouse();
 
@@ -88,6 +88,14 @@
     scene.cameras.main.startFollow(loki, false, 0.14, 0.14);
 
     keys = scene.input.keyboard.addKeys('W,A,S,D,LEFT,RIGHT,UP,DOWN,SPACE,SHIFT');
+    keys.SHIFT.on('down', () => {
+      loki.boost = 1;
+      if (sfxToggle.checked) { sSprint.currentTime = 0; sSprint.play(); }
+    });
+    keys.SHIFT.on('up', () => {
+      loki.boost = 0;
+      // TODO: implement cooldown or resource bar before re-enabling boost
+    });
     const prevent = e => e.preventDefault();
     ['touchstart','touchmove','touchend','gesturestart'].forEach(ev=> document.addEventListener(ev, prevent, {passive:false}));
     const cvs = scene.game.canvas;
@@ -151,7 +159,7 @@
     }
     if(loki){ loki.destroy(); } if(merlin){ merlin.destroy(); merlin=null; } if(yumi){ yumi.destroy(); yumi=null; }
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=360; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=480; loki.boost=0;
     scene.physics.add.collider(loki, obstGroup);
     miceGroup.clear(true,true);
     for(let i=0;i<26;i++) spawnMouse();

--- a/game.test.js
+++ b/game.test.js
@@ -1,6 +1,14 @@
 const fs = require('fs');
 const vm = require('vm');
 
+global.localStorage = {
+  _s: {},
+  clear() { this._s = {}; },
+  getItem(k) { return Object.prototype.hasOwnProperty.call(this._s, k) ? this._s[k] : null; },
+  setItem(k, v) { this._s[k] = String(v); },
+  removeItem(k) { delete this._s[k]; }
+};
+
 describe('saveSlot and loadSlot', () => {
   let context;
 
@@ -9,8 +17,11 @@ describe('saveSlot and loadSlot', () => {
     localStorage.clear();
     // extract functions from game.js
     const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
-    const saveSlotCode = code.match(/function saveSlot\(\)\{[\s\S]*?\}/)[0];
-    const loadSlotCode = code.match(/function loadSlot\(\)\{[\s\S]*?\}/)[0];
+    const startSave = code.indexOf('function saveSlot()');
+    const startLoad = code.indexOf('function loadSlot()');
+    const startUpdate = code.indexOf('function update', startLoad);
+    const saveSlotCode = code.slice(startSave, startLoad).trim();
+    const loadSlotCode = code.slice(startLoad, startUpdate).trim();
 
     context = {
       localStorage: global.localStorage,
@@ -43,5 +54,46 @@ describe('saveSlot and loadSlot', () => {
       countM: 2,
       countY: 3
     });
+  });
+});
+
+describe('loki boost mechanics', () => {
+  test('boost toggles speed and animation', () => {
+    const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+    const movementCode = code.match(/const left = keys.A.isDown[\s\S]*?loki.play\([^\n]*\);/)[0];
+
+    const loki = {
+      speed: 480,
+      boost: 0,
+      body: {
+        velocity: { x: 0, y: 0 },
+        setVelocity(x, y) { this.velocity = { x, y }; }
+      },
+      play: jest.fn()
+    };
+    const ctx = {
+      keys: {
+        A: { isDown: false },
+        D: { isDown: true },
+        W: { isDown: false },
+        S: { isDown: false },
+        LEFT: { isDown: false },
+        RIGHT: { isDown: false },
+        UP: { isDown: false },
+        DOWN: { isDown: false }
+      },
+      jdx: 0,
+      jdy: 0,
+      loki
+    };
+
+    vm.runInNewContext(`(function(){${movementCode}})()`, ctx);
+    expect(loki.body.velocity.x).toBeCloseTo(480);
+    expect(loki.play).toHaveBeenLastCalledWith('loki_run', true);
+
+    loki.boost = 1;
+    vm.runInNewContext(`(function(){${movementCode}})()`, ctx);
+    expect(loki.body.velocity.x).toBeCloseTo(640);
+    expect(loki.play).toHaveBeenLastCalledWith('loki_sprint', true);
   });
 });


### PR DESCRIPTION
## Summary
- Increase Loki's base speed to feel more agile and enable SHIFT-based sprint boosting.
- Play sprint SFX and toggle boost state on SHIFT presses.
- Add unit test verifying sprint boost alters speed and animation.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b46174718832699773d9a3f920e3e