### PR TITLE
refactor: centralize obstacle map

### DIFF
--- a/game.js
+++ b/game.js
@@ -4,6 +4,12 @@
   const biomes = ['kitchen','garden','garage','street'];
   const META = {w:160,h:130,rows:{idle:0,run:1,sprint:2},frames:{idle:6,run:8,sprint:8}};
   const WORLD = { w: 4200, h: 2800 };
+  const OBST = {
+    0:[[600,300,460,60],[1100,500,420,80],[1900,1200,500,60],[2600,800,380,90]],
+    1:[[700,700,300,140],[1600,1000,420,120],[2300,400,260,100],[3200,900,380,90]],
+    2:[[800,600,420,110],[1500,1200,380,90],[2400,800,420,120],[3000,1400,560,80]],
+    3:[[600,600,600,100],[1700,900,500,90],[2600,700,420,90],[3400,1200,480,100]]
+  };
 
   const hud = document.getElementById('hud'), menu = document.getElementById('menu');
   const cL=document.getElementById('cL'), cM=document.getElementById('cM'), cY=document.getElementById('cY');
@@ -65,12 +71,6 @@
 
     layers = { bg: scene.add.tileSprite(0,0, WORLD.w, WORLD.h, biomes[(lvl-1)%biomes.length]).setOrigin(0,0).setScrollFactor(0) };
 
-    const OBST = {
-      0:[[600,300,460,60],[1100,500,420,80],[1900,1200,500,60],[2600,800,380,90]],
-      1:[[700,700,300,140],[1600,1000,420,120],[2300,400,260,100],[3200,900,380,90]],
-      2:[[800,600,420,110],[1500,1200,380,90],[2400,800,420,120],[3000,1400,560,80]],
-      3:[[600,600,600,100],[1700,900,500,90],[2600,700,420,90],[3400,1200,480,100]]
-    };
     obstGroup = scene.physics.add.staticGroup();
     for(const o of OBST[(lvl-1)%4]){
       const r = scene.add.rectangle(o[0]+o[2]/2, o[1]+o[3]/2, o[2], o[3], 0x222a55, 0.55).setStrokeStyle(2,0x23284a);
@@ -141,13 +141,7 @@
     scene.cameras.main.setScroll(0,0);
     layers.bg.setTexture(biomes[(lvl-1)%biomes.length]);
     obstGroup.clear(true,true);
-    const OBST2 = {
-      0:[[600,300,460,60],[1100,500,420,80],[1900,1200,500,60],[2600,800,380,90]],
-      1:[[700,700,300,140],[1600,1000,420,120],[2300,400,260,100],[3200,900,380,90]],
-      2:[[800,600,420,110],[1500,1200,380,90],[2400,800,420,120],[3000,1400,560,80]],
-      3:[[600,600,600,100],[1700,900,500,90],[2600,700,420,90],[3400,1200,480,100]]
-    };
-    for(const o of OBST2[(lvl-1)%4]){
+    for(const o of OBST[(lvl-1)%4]){
       const r = scene.add.rectangle(o[0]+o[2]/2, o[1]+o[3]/2, o[2], o[3], 0x222a55, 0.55).setStrokeStyle(2,0x23284a);
       obstGroup.add(r);
     }


### PR DESCRIPTION
## Summary
- hoist obstacle layout into shared `OBST`
- reuse `OBST` in `create` and `resetWorld`

## Testing
- `npm test` *(fails: localStorage is not defined)*
- `npm test -- --env=jsdom` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689b481552288326898834d6ad5b70c9