### PR TITLE
Add sprint toggle and increase Loki speed

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,7 +78,7 @@
     }
 
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=360; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=480; loki.boost=0;
     loki.body.setDrag(300, 300);
     miceGroup = scene.physics.add.group({ allowGravity:false });
     for(let i=0;i<26;i++) spawnMouse();
@@ -89,6 +89,11 @@
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
 
     keys = scene.input.keyboard.addKeys('W,A,S,D,LEFT,RIGHT,UP,DOWN,SPACE,SHIFT');
+    keys.SHIFT.on('down', () => {
+      loki.boost = 1;
+      if (sfxToggle.checked) { sSprint.currentTime = 0; sSprint.play(); }
+    });
+    keys.SHIFT.on('up', () => { loki.boost = 0; });
     const prevent = e => e.preventDefault();
     ['touchstart','touchmove','touchend','gesturestart'].forEach(ev=> document.addEventListener(ev, prevent, {passive:false}));
     const cvs = scene.game.canvas;
@@ -153,7 +158,7 @@
     }
     if(loki){ loki.destroy(); } if(merlin){ merlin.destroy(); merlin=null; } if(yumi){ yumi.destroy(); yumi=null; }
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=360; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=480; loki.boost=0;
     loki.body.setDrag(300, 300);
     scene.physics.add.collider(loki, obstGroup);
     miceGroup.clear(true,true);


### PR DESCRIPTION
## Summary
- Increase Loki's base speed and reset boost in create and resetWorld
- Add Shift key handlers to enable sprint boost with sound effect

## Testing
- `npx jest` *(fails: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689b49162e408326a3fc07540c68ac7b