### PR TITLE
Use slot0 storage key and update tests

### DIFF
--- a/game.js
+++ b/game.js
@@ -114,7 +114,7 @@
     btnNext.onclick = () => { ovWin.style.display='none'; nextLevel(); scene.scene.resume(); };
     btnRetry.onclick = () => { ovLose.style.display='none'; newGame(); startGame(); scene.scene.resume(); };
 
-    updHUD(); if(localStorage.getItem('slot')) btnContinue.style.display='';
+    updHUD(); if(localStorage.getItem('slot0') || localStorage.getItem('slot')) btnContinue.style.display='';
     showMenu();
   }
 
@@ -161,8 +161,8 @@
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
   }
 
-  function saveSlot(){ const s={lvl,goal,goalCaught,countL,countM,countY}; localStorage.setItem('slot',JSON.stringify(s)); }
-  function loadSlot(){ const s=localStorage.getItem('slot'); if(!s) return false; const o=JSON.parse(s); lvl=o.lvl; goal=o.goal; goalCaught=o.goalCaught; countL=o.countL; countM=o.countM; countY=o.countY; updHUD(); resetWorld(); return true; }
+  function saveSlot(){ const s={lvl,goal,goalCaught,countL,countM,countY}; localStorage.setItem('slot0',JSON.stringify(s)); }
+  function loadSlot(){ const s=localStorage.getItem('slot0') || localStorage.getItem('slot'); if(!s) return false; const o=JSON.parse(s); lvl=o.lvl; goal=o.goal; goalCaught=o.goalCaught; countL=o.countL; countM=o.countM; countY=o.countY; updHUD(); resetWorld(); if(!localStorage.getItem('slot0')) localStorage.setItem('slot0', s); return true; }
 
   function update(time, delta){
     if(state!=='play') return;

--- a/game.test.js
+++ b/game.test.js
@@ -5,12 +5,19 @@ describe('saveSlot and loadSlot', () => {
   let context;
 
   beforeEach(() => {
-    // clear storage
-    localStorage.clear();
+    // mock storage
+    let store = {};
+    global.localStorage = {
+      getItem: key => (key in store ? store[key] : null),
+      setItem: (key, value) => { store[key] = String(value); },
+      removeItem: key => { delete store[key]; },
+      clear: () => { store = {}; }
+    };
+
     // extract functions from game.js
     const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
-    const saveSlotCode = code.match(/function saveSlot\(\)\{[\s\S]*?\}/)[0];
-    const loadSlotCode = code.match(/function loadSlot\(\)\{[\s\S]*?\}/)[0];
+    const saveSlotCode = code.match(/function saveSlot\(\)\{[^]*?localStorage\.setItem[^]*?\}\s*/)[0];
+    const loadSlotCode = code.match(/function loadSlot\(\)\{[^]*?return true;\s*\}/)[0];
 
     context = {
       localStorage: global.localStorage,
@@ -29,6 +36,9 @@ describe('saveSlot and loadSlot', () => {
   test('restores game state after save/load', () => {
     Object.assign(context, { lvl: 3, goal: 100, goalCaught: 50, countL: 1, countM: 2, countY: 3 });
     context.saveSlot();
+
+    expect(localStorage.getItem('slot0')).not.toBeNull();
+    expect(localStorage.getItem('slot')).toBeNull();
 
     Object.assign(context, { lvl: 0, goal: 0, goalCaught: 0, countL: 0, countM: 0, countY: 0 });
     const result = context.loadSlot();


### PR DESCRIPTION
## Summary
- switch saveSlot and loadSlot to use the `slot0` storage key
- migrate legacy `slot` saves and update continue button check
- adapt tests to assert the new key and include a localStorage mock

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b48169ce4832689c12e229154d2ed