### PR TITLE
Increase Loki base speed to 750

### DIFF
--- a/game.js
+++ b/game.js
@@ -87,7 +87,7 @@
     }
 
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=600; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=750; loki.boost=0;
     loki.body.setDrag(180, 180);
     miceGroup = scene.physics.add.group({ allowGravity:false });
     for (let i = 0; i < maxMice(); i++) spawnMouse();
@@ -170,7 +170,7 @@
     }
     if(loki){ loki.destroy(); } if(merlin){ merlin.destroy(); merlin=null; } if(yumi){ yumi.destroy(); yumi=null; }
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10).setScale(0.6);
-    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=600; loki.boost=0;
+    loki.play('loki_idle'); loki.setCircle(26, META.w/2-26, META.h/2-26); loki.speed=750; loki.boost=0;
     loki.body.setDrag(180, 180);
     scene.physics.add.collider(loki, obstGroup);
     miceGroup.clear(true,true);


### PR DESCRIPTION
## Summary
- Raise Loki's default speed from 600 to 750 for faster movement
- Reviewed boost mechanic; retains existing +200 bonus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b50258fbc8326ac0f783864e30e4a