### PR TITLE
Remove query strings from asset paths for Phaser

### DIFF
--- a/game.js
+++ b/game.js
@@ -53,12 +53,12 @@
     scene=this;
     for(const b of biomes){
       // Use the existing single background image for all parallax layers
-      this.load.image(b, `${b}.webp?v=107`);
+      this.load.image(b, `${b}.webp`);
     }
-    this.load.spritesheet('loki', 'loki_sheet.webp?v=107', { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('merlin', 'merlin_sheet.webp?v=107', { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('yumi', 'yumi_sheet.webp?v=107', { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('mouse', 'mouse_sheet.webp?v=107', { frameWidth: 56, frameHeight: 36 });
+    this.load.spritesheet('loki', 'loki_sheet.webp', { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('merlin', 'merlin_sheet.webp', { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('yumi', 'yumi_sheet.webp', { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('mouse', 'mouse_sheet.webp', { frameWidth: 56, frameHeight: 36 });
   }
 
   function create(){


### PR DESCRIPTION
## Summary
- Load background images without version query strings
- Load sprite sheets without version query strings

## Testing
- `npm test`
- `node - <<'NODE'\nconst fs=require('fs');\nconsole.log('kitchen.webp exists?',fs.existsSync('kitchen.webp'));\nconsole.log('kitchen.webp?v=107 exists?',fs.existsSync('kitchen.webp?v=107'));\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_689b5973fed88326a773602a2a022652