### PR TITLE
Increase mouse spawn scaling for higher levels

### DIFF
--- a/game.js
+++ b/game.js
@@ -47,7 +47,7 @@
   let keys;
   let jdx=0,jdy=0, swipeActive=false, swipeStart=null;
   const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?40:50;
-  const maxMice = () => Math.floor(BASE_MICE * (1 + 0.25*(lvl-1)));
+  const maxMice = () => Math.floor(BASE_MICE * (1 + 0.5*(lvl-1)));
 
   function preload(){
     scene=this;


### PR DESCRIPTION
## Summary
- Increase mouse spawn capacity growth from 25% to 50% per level for denser populations.

## Testing
- `npm test`
- `node -e "const BASE_MICE=/iPhone|iPad|iPod/.test('')?40:50; const maxMice=lvl=>Math.floor(BASE_MICE*(1+0.5*(lvl-1))); for(let l=1;l<=5;l++) console.log(l,maxMice(l));"`

------
https://chatgpt.com/codex/tasks/task_e_689b597f8f4c8326a3ecacc600e08422