### PR TITLE
Align initial goal value across HUD and game logic

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,7 +25,8 @@
   const ovLose=document.getElementById('ovLose'), loseMsg=document.getElementById('loseMsg'), btnRetry=document.getElementById('btnRetry');
   const bgm = document.getElementById('bgm'); const sCatch=document.getElementById('sCatch'), sPounce=document.getElementById('sPounce'), sSprint=document.getElementById('sSprint');
 
-  let state='menu',lvl=1,goal=35,goalCaught=0;
+  const INITIAL_GOAL = 35;
+  let state='menu',lvl=1,goal=INITIAL_GOAL,goalCaught=0;
   let countL=0,countM=0,countY=0;
   function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-goalCaught); }
 
@@ -157,7 +158,7 @@
 
   function startGame(){ state='play'; hud.style.display='flex'; menu.style.display='none'; if(bgm.paused && sfxToggle.checked) bgm.play(); }
   function showMenu(){ state='menu'; hud.style.display='none'; menu.style.display='flex'; }
-  function newGame(){ lvl=1; goal=35; goalCaught=0; countL=countM=countY=0; updHUD(); resetWorld(); }
+  function newGame(){ lvl=1; goal=INITIAL_GOAL; goalCaught=0; countL=countM=countY=0; updHUD(); resetWorld(); }
   function nextLevel(){ goal = Math.floor(goal*1.25); goalCaught=0; countL=0; countM=0; countY=0; updHUD(); resetWorld(); }
 
   function resetWorld(){

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <span class="pill">Merlin: <b id="cM">0</b></span>
   <span class="pill">Yumi: <b id="cY">0</b></span>
   <span class="pill">Level: <b id="lvl">1</b></span>
-  <span class="pill">Ziel: <b id="goalNeed">25</b> (Rest <b id="goalLeft">25</b>)</span>
+  <span class="pill">Ziel: <b id="goalNeed">35</b> (Rest <b id="goalLeft">35</b>)</span>
   <span class="pill" style="margin-left:auto"><button id="btnPause">Pause</button> <button id="btnRestart">Neu</button> <button id="btnMenu">Menü</button> <button id="btnMap">🗺️</button> <button id="btnMute">🔊</button></span>
 </div>
 <div class="joy" id="joy"><div class="stick" id="stick"></div></div>


### PR DESCRIPTION
## Summary
- Set HUD's initial goal counters to 35.
- Introduce shared `INITIAL_GOAL` constant and use it when starting a new game.

## Testing
- `node - <<'NODE' ...`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5983e44c8326bc47afd3d211c9ab