### PR TITLE
Mirror Loki sprite when moving left

### DIFF
--- a/game.js
+++ b/game.js
@@ -94,6 +94,7 @@
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
     loki.speed=750; loki.boost=0;
     loki.body.setDrag(180, 180);
+    loki.setFlipX(loki.body.velocity.x < 0);
     miceGroup = scene.physics.add.group({ allowGravity:false });
     for (let i = 0; i < maxMice(); i++) spawnMouse();
 
@@ -183,6 +184,7 @@
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
     loki.speed=750; loki.boost=0;
     loki.body.setDrag(180, 180);
+    loki.setFlipX(loki.body.velocity.x < 0);
     scene.physics.add.collider(loki, obstGroup);
     miceGroup.clear(true,true);
     for (let i = 0; i < maxMice(); i++) spawnMouse();
@@ -220,6 +222,7 @@
     let ay = (up?-1:0) + (down?1:0) + jdy;
     let len = Math.hypot(ax,ay)||1; ax/=len; ay/=len;
     loki.body.setVelocity(ax*(loki.speed+(loki.boost?200:0)), ay*(loki.speed+(loki.boost?200:0)));
+    loki.setFlipX(loki.body.velocity.x < 0);
     loki.play(Math.hypot(loki.body.velocity.x,loki.body.velocity.y)>30 ? (loki.boost?'loki_sprint':'loki_run') : 'loki_idle', true);
 
     if(lvl>=2 && !merlin){


### PR DESCRIPTION
## Summary
- Flip Loki's sprite based on horizontal velocity during updates
- Reset Loki's orientation whenever the character is spawned or the world resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5b943d9c83269d037fc0406576f7