### PR TITLE
Center mouse hitbox for accurate collisions

### DIFF
--- a/game.js
+++ b/game.js
@@ -146,7 +146,8 @@
 
   function spawnMouse(){
     const m = scene.physics.add.sprite(80+Math.random()*(WORLD.w-160), 80+Math.random()*(WORLD.h-160), 'mouse').play('mouse_run');
-    m.setCircle(10, 20, 14);
+    const d = 36;
+    m.setCircle(d / 2, (56 - d) / 2, (36 - d) / 2); // 36px diameter centered in 56×36 sprite
     m.base = 120 + Math.random()*40;
     m.dir = new Phaser.Math.Vector2((Math.random()*2-1),(Math.random()*2-1)).normalize();
     m.body.setVelocity(m.dir.x*m.base, m.dir.y*m.base);


### PR DESCRIPTION
## Summary
- center the mouse collision circle with a 36px diameter so Loki destroys mice on contact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5d8a6d388326a477ca15af54f86c