### PR TITLE
Add skill buttons with cooldown-based abilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,11 @@
   <span class="pill" style="margin-left:auto"><button id="btnPause">Pause</button> <button id="btnRestart">Neu</button> <button id="btnMenu">Menü</button> <button id="btnMap">🗺️</button> <button id="btnMute">🔊</button></span>
 </div>
 <div class="joy" id="joy"><div class="stick" id="stick"></div></div>
-<!-- Skill buttons placeholder - functionality not yet implemented -->
-<!-- <div class="skillbar"><button class="skillbtn" id="btnPounce">Pounce</button><button class="skillbtn" id="btnSprint">Sprint</button><button class="skillbtn" id="btnSense">Sense</button></div> -->
+<div class="skillbar">
+  <button class="skillbtn" id="btnPounce">Pounce</button>
+  <button class="skillbtn" id="btnSprint">Sprint</button>
+  <button class="skillbtn" id="btnSense">Sense</button>
+</div>
 <canvas id="minimap" class="minimap" width="180" height="120"></canvas>
 
 <div class="menu" id="menu"><div class="panel">
@@ -69,5 +72,5 @@
 <audio id="sSprint" src="sprint.wav"></audio>
 
 <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
-<script src="game.js?v=107"></script>
+<script src="game.js?v=108"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- Reactivate skill bar with Pounce, Sprint and Sense buttons
- Add DOM hooks and cooldown logic for each skill
- Implement skill effects and cooldown display reset on pause/menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5cd2a0808326b883d349a682db26