### PR TITLE
Ensure Loki stays within world bounds

### DIFF
--- a/game.js
+++ b/game.js
@@ -88,6 +88,7 @@
     }
 
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10);
+    loki.setCollideWorldBounds(true);
     const scale = 0.75;
     const radius = 32 * scale;
     loki.setScale(scale);
@@ -208,6 +209,7 @@
     }
     if(loki){ loki.destroy(); } if(merlin){ merlin.destroy(); merlin=null; } if(yumi){ yumi.destroy(); yumi=null; }
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10);
+    loki.setCollideWorldBounds(true);
     const scale = 0.75;
     const radius = 32 * scale;
     loki.setScale(scale);

--- a/game.test.js
+++ b/game.test.js
@@ -56,3 +56,23 @@ describe('saveSlot and loadSlot', () => {
       });
   });
 });
+
+describe('Loki world bounds', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+
+  test('create includes world bounds collision', () => {
+    const createSection = code.match(/function create\(\)[^]*?scene\.cameras\.main\.startFollow/)[0];
+    const spriteIdx = createSection.indexOf("loki = scene.physics.add.sprite");
+    expect(spriteIdx).toBeGreaterThan(-1);
+    const collideIdx = createSection.indexOf("loki.setCollideWorldBounds(true)", spriteIdx);
+    expect(collideIdx).toBeGreaterThan(spriteIdx);
+  });
+
+  test('resetWorld includes world bounds collision', () => {
+    const resetSection = code.match(/function resetWorld\(\)[^]*?scene\.cameras\.main\.startFollow/)[0];
+    const spriteIdx = resetSection.indexOf("loki = scene.physics.add.sprite");
+    expect(spriteIdx).toBeGreaterThan(-1);
+    const collideIdx = resetSection.indexOf("loki.setCollideWorldBounds(true)", spriteIdx);
+    expect(collideIdx).toBeGreaterThan(spriteIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent the Loki sprite from leaving the world by enabling world-bound collisions in `create` and `resetWorld`
- Add unit tests asserting that Loki is configured to collide with world bounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b609126b48326829dbeb00f215131