### PR TITLE
feat: expand Loki hitbox and handle mouse collisions

### DIFF
--- a/game.js
+++ b/game.js
@@ -89,7 +89,7 @@
 
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10);
     const scale = 0.75;
-    const radius = 32 * scale;
+    const radius = 42 * scale;
     loki.setScale(scale);
     loki.play('loki_idle');
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
@@ -100,7 +100,7 @@
     for (let i = 0; i < maxMice(); i++) spawnMouse();
 
     scene.physics.add.collider(loki, obstGroup);
-      scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; goalCaught++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkEnd(); });
+    scene.physics.add.collider(loki, miceGroup, catchMouse);
 
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
 
@@ -159,6 +159,16 @@
     return m;
   }
 
+  function catchMouse(cat, m){
+    m.destroy();
+    countL++; goalCaught++; xp++;
+    if(sfxToggle.checked){
+      sCatch.currentTime=0; sCatch.play();
+    }
+    updHUD();
+    checkEnd();
+  }
+
   function resetCooldowns(){
     skillbar?.querySelectorAll('.skillbtn').forEach(btn => btn.removeAttribute('data-cd'));
   }
@@ -209,7 +219,7 @@
     if(loki){ loki.destroy(); } if(merlin){ merlin.destroy(); merlin=null; } if(yumi){ yumi.destroy(); yumi=null; }
     loki = scene.physics.add.sprite(WORLD.w/2, WORLD.h/2, 'loki').setDepth(10);
     const scale = 0.75;
-    const radius = 32 * scale;
+    const radius = 42 * scale;
     loki.setScale(scale);
     loki.play('loki_idle');
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
@@ -219,6 +229,7 @@
     scene.physics.add.collider(loki, obstGroup);
     miceGroup.clear(true,true);
     for (let i = 0; i < maxMice(); i++) spawnMouse();
+    scene.physics.add.collider(loki, miceGroup, catchMouse);
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
   }
 

--- a/game.test.js
+++ b/game.test.js
@@ -56,3 +56,32 @@ describe('saveSlot and loadSlot', () => {
       });
   });
 });
+
+describe('catchMouse', () => {
+  let context;
+
+  beforeEach(() => {
+    const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+    const catchMouseCode = code.match(/function catchMouse\(cat, m\)\{[\s\S]*?\n\s*\}\n\n/)[0];
+    context = {
+      countL: 0,
+      goalCaught: 0,
+      xp: 0,
+      sfxToggle: { checked: false },
+      sCatch: { currentTime: 0, play: jest.fn() },
+      updHUD: jest.fn(),
+      checkEnd: jest.fn()
+    };
+    vm.createContext(context);
+    vm.runInContext(catchMouseCode, context);
+  });
+
+  test('destroys mouse and updates counters', () => {
+    const mouse = { destroy: jest.fn() };
+    context.catchMouse({}, mouse);
+    expect(mouse.destroy).toHaveBeenCalled();
+    expect(context.countL).toBe(1);
+    expect(context.goalCaught).toBe(1);
+    expect(context.xp).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- increase Loki's collision radius and process mouse capture via collider
- centralize mouse catch logic to update counters and XP
- test that a mouse is removed and stats increment when Loki collides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b6092d9d08326bf598704c9459227