### PR TITLE
Restore tests after merge conflict

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -57,6 +57,20 @@ describe('saveSlot and loadSlot', () => {
   });
 });
 
+describe('catchMouse', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+
+  test('overlap destroys mouse and increments counters', () => {
+    const overlap = code.match(/scene\.physics\.add\.overlap\(loki,\s*miceGroup,\s*\(cat,\s*m\)=>\{[^]*?\}\);/);
+    expect(overlap).not.toBeNull();
+    const body = overlap[0];
+    expect(body).toMatch(/m\.destroy\(\)/);
+    expect(body).toMatch(/countL\+\+/);
+    expect(body).toMatch(/goalCaught\+\+/);
+    expect(body).toMatch(/xp\+\+/);
+  });
+});
+
 describe('Loki world bounds', () => {
   const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
 


### PR DESCRIPTION
## Summary
- Restore catchMouse test verifying overlap destroys mice and increments counts
- Keep Loki world-bounds tests to ensure sprite stays within game area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b62b46a288326b3e25057552eab8c