### PR TITLE
Increase Loki speed to 1000

### DIFF
--- a/game.js
+++ b/game.js
@@ -94,7 +94,7 @@
     loki.setScale(scale);
     loki.play('loki_idle');
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
-    loki.speed=750; loki.boost=0;
+    loki.speed=1000; loki.boost=0;
     loki.body.setDrag(180, 180);
     loki.setFlipX(loki.body.velocity.x < 0);
     miceGroup = scene.physics.add.group({ allowGravity:false });
@@ -217,7 +217,7 @@
     loki.setScale(scale);
     loki.play('loki_idle');
     loki.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
-    loki.speed=750; loki.boost=0;
+    loki.speed=1000; loki.boost=0;
     loki.body.setDrag(180, 180);
     loki.setFlipX(loki.body.velocity.x < 0);
     scene.physics.add.collider(loki, obstGroup);

--- a/game.test.js
+++ b/game.test.js
@@ -90,3 +90,12 @@ describe('Loki world bounds', () => {
     expect(collideIdx).toBeGreaterThan(spriteIdx);
   });
 });
+
+describe('speed configuration', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+
+  test('uses updated Loki speed value', () => {
+    const matches = code.match(/loki.speed=1000/g) || [];
+    expect(matches.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Increase Loki's base speed to 1000 in both creation and reset routines while keeping boost at 0
- Add test verifying updated speed configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6542bab88326b57b9edc610f4c2d