### PR TITLE
Clarify parallax background reuse in resetWorld

### DIFF
--- a/game.js
+++ b/game.js
@@ -209,7 +209,7 @@
     scene.cameras.main.stopFollow();
     scene.cameras.main.setScroll(0,0);
     const biome = biomes[(lvl-1)%biomes.length];
-    // All parallax layers use the same single background image
+    // Reuse one background image per biome for all parallax layers
     layers.far.setTexture(biome);
     layers.mid.setTexture(biome);
     layers.near.setTexture(biome);


### PR DESCRIPTION
## Summary
- clarify that resetWorld reuses one biome background for all parallax layers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6a8da8808326b5f2cc3a0cd52320