### PR TITLE
Add test for nextLevel counter reset

### DIFF
--- a/game.js
+++ b/game.js
@@ -199,6 +199,7 @@
   }
 
   function nextLevel(){
+    lvl++;
     goal = Math.floor(goal*1.25); goalCaught=0; countL=0; countM=0; countY=0;
     updHUD();
     resetWorld();

--- a/game.test.js
+++ b/game.test.js
@@ -103,3 +103,29 @@ describe('speed configuration', () => {
     expect(matches.length).toBe(2);
   });
 });
+
+describe('nextLevel', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+
+  test('increments level and resets counters', () => {
+    const nextLevelCode = code.match(/function nextLevel\(\)\{[^]*?\}\n/)[0];
+    const context = {
+      updHUD: () => {},
+      resetWorld: () => {},
+      resetCooldowns: () => {}
+    };
+    vm.createContext(context);
+    vm.runInContext(`
+      var lvl=1, goal=35, goalCaught=5, countL=1, countM=2, countY=3;
+      ${nextLevelCode}
+    `, context);
+
+    context.nextLevel();
+    const { lvl, goalCaught, countL, countM, countY } = context;
+    expect(lvl).toBe(2);
+    expect(goalCaught).toBe(0);
+    expect(countL).toBe(0);
+    expect(countM).toBe(0);
+    expect(countY).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `nextLevel` increments the level and resets counters
- add unit test for `nextLevel`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6a8cf82c8326b47c38c093f35e14