### PR TITLE
Increment level during level transition

### DIFF
--- a/game.js
+++ b/game.js
@@ -199,6 +199,7 @@
   }
 
   function nextLevel(){
+    lvl++;
     goal = Math.floor(goal*1.25); goalCaught=0; countL=0; countM=0; countY=0;
     updHUD();
     resetWorld();


### PR DESCRIPTION
## Summary
- Increment the level counter at the start of `nextLevel`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6a8e00cc8326ae86582cccf320b1