### PR TITLE
chore: correct HTML doctype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html><html lang="de"><head><meta charset="utf-8">
+<!DOCTYPE html><html lang="de"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no">
 <title>Loki – Mäusejagd v10.6 (Phaser) Alpha</title>
 <link rel="preconnect" href="https://cdn.jsdelivr.net">


### PR DESCRIPTION
## Summary
- normalize HTML doctype to uppercase for standards compliance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6a8f8e688326b51eba4b16ddf81d