### PR TITLE
Delay start buttons until game ready

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,6 +25,7 @@
   const ovLose=document.getElementById('ovLose'), loseMsg=document.getElementById('loseMsg'), btnRetry=document.getElementById('btnRetry');
   const bgm = document.getElementById('bgm'); const sCatch=document.getElementById('sCatch'), sPounce=document.getElementById('sPounce'), sSprint=document.getElementById('sSprint');
   const skillbar = document.querySelector('.skillbar');
+  let gameReady = false;
 
   const INITIAL_GOAL = 35;
     let state='menu',lvl=1,goal=INITIAL_GOAL,goalCaught=0;
@@ -43,8 +44,8 @@
   function initMenu(){
     document.getElementById('btnSettings').onclick = ()=>{ settings.style.display = settings.style.display? '' : 'block'; credits.style.display='none'; };
     document.getElementById('btnCredits').onclick = ()=>{ credits.style.display = credits.style.display? '' : 'block'; settings.style.display='none'; };
-    btnNew.onclick = ()=>{ newGame(); startGame(); };
-    btnContinue.onclick = ()=>{ if(loadSlot()) startGame(); else newGame(), startGame(); };
+    btnNew.onclick = ()=>{ if(!gameReady) return; newGame(); startGame(); };
+    btnContinue.onclick = ()=>{ if(!gameReady) return; if(loadSlot()) startGame(); else newGame(), startGame(); };
     btnRestart.onclick = ()=>{ newGame(); startGame(); };
     btnMenu.onclick = ()=>{ showMenu(); saveSlot(); };
     btnMap.onclick = ()=>{ mm.style.display = mm.style.display?'':'block'; };
@@ -152,6 +153,9 @@
     joy.addEventListener('pointerup',()=>{ if(ctrl.value!=='joystick') return; setStick(0,0); jdx=jdy=0; });
     function moveStick(e){ const rect=joy.getBoundingClientRect(); const t=e.touches?e.touches[0]:e; const dx=t.clientX-(rect.left+rect.width/2); const dy=t.clientY-(rect.top+rect.height/2); const max=Math.min(rect.width,rect.height)/2 - 18; const len=Math.hypot(dx,dy)||1; const nx=dx/len*Math.min(len,max), ny=dy/len*Math.min(len,max); setStick(nx,ny); const dz=0.12; const rx=(nx/max), ry=(ny/max); jdx = Math.abs(rx)<dz ? 0 : rx; jdy = Math.abs(ry)<dz ? 0 : ry; }
     function setStick(nx,ny){ stick.style.transform = `translate(calc(-50% + ${nx}px), calc(-50% + ${ny}px))`; }
+
+    gameReady = true;
+    btnNew.disabled = btnContinue.disabled = false;
 
   }
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 .pill{background:#14183a;border:1px solid #23284a;border-radius:999px;padding:8px 12px;box-shadow:0 6px 18px rgba(0,0,0,.35);pointer-events:auto}
 .menu{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:20px;z-index:20;background:linear-gradient(180deg,#0b0e1a,#0f1221)}
 .panel{max-width:1000px;width:100%;background:#121534;border:1px solid #23284a;border-radius:16px;padding:16px;box-shadow:0 30px 80px rgba(0,0,0,.35)}
-.panel h1{margin:0 0 8px;font-size:clamp(22px,4vw,42px)} .btn{display:block;width:100%;margin:8px 0;padding:12px 14px;border:1px solid #23284a;background:#0e1230;border-radius:12px;color:#ecf1ff;font-weight:800}
+.panel h1{margin:0 0 8px;font-size:clamp(22px,4vw,42px)} .btn{display:block;width:100%;margin:8px 0;padding:12px 14px;border:1px solid #23284a;background:#0e1230;border-radius:12px;color:#ecf1ff;font-weight:800} .btn:disabled{opacity:.5;pointer-events:none}
 .joy{position:fixed; left: max(16px, env(safe-area-inset-left)); bottom: calc(18px + env(safe-area-inset-bottom)); width:160px; height:160px; border-radius:50%; background:#11162acc; border:1px solid #23284a; touch-action:none; pointer-events:auto; z-index:9}
 .joy.hidden{pointer-events:none; opacity:.15}
 .stick{position:absolute; left:50%; top:50%; width:70px; height:70px; transform:translate(-50%,-50%); border-radius:50%; background:#1c2144; border:2px solid #23284a; box-shadow:0 8px 16px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.05)}
@@ -42,8 +42,8 @@
 
 <div class="menu" id="menu"><div class="panel">
   <h1>🐱 Loki – Mäusejagd <small>v10.6 (Phaser) alpha</small></h1>
-  <button class="btn" id="btnContinue" style="display:none">Fortsetzen</button>
-  <button class="btn" id="btnNew">Neues Spiel</button>
+  <button class="btn" id="btnContinue" style="display:none" disabled>Fortsetzen</button>
+  <button class="btn" id="btnNew" disabled>Neues Spiel</button>
   <button class="btn" id="btnSettings">Einstellungen</button>
   <button class="btn" id="btnCredits">Credits</button>
   <div id="settings" style="display:none; margin-top:8px">


### PR DESCRIPTION
## Summary
- Add `gameReady` flag to track world initialization
- Gate new/continue actions on readiness and enable buttons once the scene loads
- Disable start buttons in HTML/CSS until the game is ready

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c10c3c483268da4ce91b13778f7