### PR TITLE
Lower initial goal and scale progression more gently

### DIFF
--- a/game.js
+++ b/game.js
@@ -27,7 +27,7 @@
   const skillbar = document.querySelector('.skillbar');
   let gameReady = false;
 
-  const INITIAL_GOAL = 35;
+  const INITIAL_GOAL = 15;
     let state='menu',lvl=1,goal=INITIAL_GOAL,goalCaught=0;
     let countL=0,countM=0,countY=0,xp=0;
     function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-goalCaught); xpEl.textContent=xp; }
@@ -177,7 +177,7 @@
 
   function nextLevel(){
     lvl++;
-    goal = Math.floor(goal*1.25); goalCaught=0; countL=0; countM=0; countY=0;
+    goal = Math.floor(goal*1.1); goalCaught=0; countL=0; countM=0; countY=0;
     updHUD();
     resetWorld();
     resetCooldowns();

--- a/game.test.js
+++ b/game.test.js
@@ -28,7 +28,7 @@ describe('saveSlot and loadSlot', () => {
     };
     vm.createContext(context);
     vm.runInContext(`
-        var lvl=1, goal=35, goalCaught=0;
+        var lvl=1, goal=15, goalCaught=0;
         var countL=0, countM=0, countY=0, xp=0;
       ${safeGetCode}
       ${safeSetCode}
@@ -116,7 +116,7 @@ describe('nextLevel', () => {
     };
     vm.createContext(context);
     vm.runInContext(`
-      var lvl=1, goal=35, goalCaught=5, countL=1, countM=2, countY=3;
+      var lvl=1, goal=15, goalCaught=5, countL=1, countM=2, countY=3;
       ${nextLevelCode}
     `, context);
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <span class="pill">Merlin: <b id="cM">0</b></span>
     <span class="pill">Yumi: <b id="cY">0</b></span>
     <span class="pill">Level: <b id="lvl">1</b></span>
-    <span class="pill">Ziel: <b id="goalNeed">35</b> (Rest <b id="goalLeft">35</b>)</span>
+    <span class="pill">Ziel: <b id="goalNeed">15</b> (Rest <b id="goalLeft">15</b>)</span>
     <span class="pill">XP: <b id="xp">0</b></span>
   <span class="pill" style="margin-left:auto"><button id="btnPause">Pause</button> <button id="btnRestart">Neu</button> <button id="btnMenu">Menü</button> <button id="btnMap">🗺️</button> <button id="btnMute">🔊</button></span>
 </div>


### PR DESCRIPTION
## Summary
- Reduce INITIAL_GOAL to 15 for a quicker start
- Use smaller 1.1 multiplier for level goal increases
- Update HUD default goal values and tests to match new baseline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b70d9d7688326ba35682a1ff79fd1