### PR TITLE
Increase base mouse count for higher spawn levels

### DIFF
--- a/game.js
+++ b/game.js
@@ -76,7 +76,7 @@
   let scene, layers=null, loki, merlin=null, yumi=null, miceGroup, obstGroup;
   let keys;
   let jdx=0,jdy=0, swipeActive=false, swipeStart=null;
-  const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?40:50;
+  const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?80:100;
   const maxMice = () => Math.floor(BASE_MICE * (1 + 0.5*(lvl-1)));
 
   function preload(){


### PR DESCRIPTION
## Summary
- bump BASE_MICE to 80 on iOS devices and 100 elsewhere
- rely on maxMice() for initial and ongoing spawns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b70e18ad08326a35850fc885fd41c