### PR TITLE
Track progress with Loki's mouse count

### DIFF
--- a/game.js
+++ b/game.js
@@ -28,9 +28,9 @@
   let gameReady = false;
 
   const INITIAL_GOAL = 15;
-    let state='menu',lvl=1,goal=INITIAL_GOAL,goalCaught=0;
+    let state='menu',lvl=1,goal=INITIAL_GOAL;
     let countL=0,countM=0,countY=0,xp=0;
-    function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-goalCaught); xpEl.textContent=xp; }
+    function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-countL); xpEl.textContent=xp; }
 
   function safeStorageGet(key, fallback=null){ try { return localStorage.getItem(key) ?? fallback; } catch { return fallback; } }
   function safeStorageSet(key, value){ try { localStorage.setItem(key, value); } catch { } }
@@ -176,7 +176,7 @@
   }
 
   function newGame(){
-    lvl=1; goal=INITIAL_GOAL; goalCaught=0; countL=countM=countY=0; xp=0;
+    lvl=1; goal=INITIAL_GOAL; countL=countM=countY=0; xp=0;
     updHUD();
     resetWorld();
     resetCooldowns();
@@ -184,7 +184,7 @@
 
   function nextLevel(){
     lvl++;
-    goal = Math.floor(goal*1.1); goalCaught=0; countL=0; countM=0; countY=0;
+    goal = Math.floor(goal*1.1); countL=0; countM=0; countY=0;
     updHUD();
     resetWorld();
     resetCooldowns();
@@ -243,13 +243,13 @@
     for (let i = 0; i < maxMice(); i++) spawnMouse();
 
     scene.physics.add.collider(loki, obstGroup);
-    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; goalCaught++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkEnd(); });
+    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkEnd(); });
 
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
   }
 
-    function saveSlot(){ const s={lvl,goal,goalCaught,countL,countM,countY,xp}; safeStorageSet('slot0',JSON.stringify(s)); }
-    function loadSlot(){ const s=safeStorageGet('slot0') || safeStorageGet('slot'); if(!s) return false; let o; try{ o=JSON.parse(s); }catch{ return false; } lvl=o.lvl; goal=o.goal; goalCaught=o.goalCaught; countL=o.countL; countM=o.countM; countY=o.countY; xp=o.xp||0; updHUD(); resetWorld(); if(!safeStorageGet('slot0')) safeStorageSet('slot0', s); return true; }
+    function saveSlot(){ const s={lvl,goal,countL,countM,countY,xp}; safeStorageSet('slot0',JSON.stringify(s)); }
+    function loadSlot(){ const s=safeStorageGet('slot0') || safeStorageGet('slot'); if(!s) return false; let o; try{ o=JSON.parse(s); }catch{ return false; } lvl=o.lvl; goal=o.goal; countL=o.countL; countM=o.countM; countY=o.countY; xp=o.xp||0; updHUD(); resetWorld(); if(!safeStorageGet('slot0')) safeStorageSet('slot0', s); return true; }
 
   function checkEnd(){
     if(countM>=goal || countY>=goal){
@@ -258,7 +258,7 @@
       scene.scene.pause();
       return true;
     }
-    if(goalCaught>=goal){
+    if(countL>=goal){
       ovWin.style.display='flex';
       winMsg.textContent="Weiter geht's!";
       scene.scene.pause();
@@ -291,7 +291,7 @@
       merlin.speed=330;
       merlin.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
       scene.physics.add.collider(merlin, obstGroup);
-      scene.physics.add.overlap(merlin, miceGroup, (cat,m)=>{ m.destroy(); countM++; goalCaught++; updHUD(); checkEnd(); });
+      scene.physics.add.overlap(merlin, miceGroup, (cat,m)=>{ m.destroy(); countM++; updHUD(); checkEnd(); });
     }
     if(lvl>=3 && !yumi){
       yumi = scene.physics.add.sprite(WORLD.w-200,WORLD.h-200,'yumi');
@@ -302,7 +302,7 @@
       yumi.speed=300;
       yumi.setCircle(radius, META.w * scale / 2 - radius, META.h * scale / 2 - radius);
       scene.physics.add.collider(yumi, obstGroup);
-      scene.physics.add.overlap(yumi, miceGroup, (cat,m)=>{ m.destroy(); countY++; goalCaught++; updHUD(); checkEnd(); });
+      scene.physics.add.overlap(yumi, miceGroup, (cat,m)=>{ m.destroy(); countY++; updHUD(); checkEnd(); });
     }
 
     const chase = (cat)=>{

--- a/game.test.js
+++ b/game.test.js
@@ -28,7 +28,7 @@ describe('saveSlot and loadSlot', () => {
     };
     vm.createContext(context);
     vm.runInContext(`
-        var lvl=1, goal=15, goalCaught=0;
+        var lvl=1, goal=15;
         var countL=0, countM=0, countY=0, xp=0;
       ${safeGetCode}
       ${safeSetCode}
@@ -38,21 +38,20 @@ describe('saveSlot and loadSlot', () => {
   });
 
   test('restores game state after save/load', () => {
-      Object.assign(context, { lvl: 3, goal: 100, goalCaught: 50, countL: 1, countM: 2, countY: 3, xp: 7 });
+      Object.assign(context, { lvl: 3, goal: 100, countL: 1, countM: 2, countY: 3, xp: 7 });
     context.saveSlot();
 
     expect(localStorage.getItem('slot0')).not.toBeNull();
     expect(localStorage.getItem('slot')).toBeNull();
 
-      Object.assign(context, { lvl: 0, goal: 0, goalCaught: 0, countL: 0, countM: 0, countY: 0, xp: 0 });
+      Object.assign(context, { lvl: 0, goal: 0, countL: 0, countM: 0, countY: 0, xp: 0 });
     const result = context.loadSlot();
 
     expect(result).toBe(true);
-      const { lvl, goal, goalCaught, countL, countM, countY, xp } = context;
-      expect({ lvl, goal, goalCaught, countL, countM, countY, xp }).toEqual({
+      const { lvl, goal, countL, countM, countY, xp } = context;
+      expect({ lvl, goal, countL, countM, countY, xp }).toEqual({
         lvl: 3,
         goal: 100,
-        goalCaught: 50,
         countL: 1,
         countM: 2,
         countY: 3,
@@ -70,7 +69,7 @@ describe('catchMouse', () => {
     const body = overlap[0];
     expect(body).toMatch(/m\.destroy\(\)/);
     expect(body).toMatch(/countL\+\+/);
-    expect(body).toMatch(/goalCaught\+\+/);
+    expect(body).not.toMatch(/goalCaught\+\+/);
     expect(body).toMatch(/xp\+\+/);
   });
 });
@@ -116,14 +115,13 @@ describe('nextLevel', () => {
     };
     vm.createContext(context);
     vm.runInContext(`
-      var lvl=1, goal=15, goalCaught=5, countL=1, countM=2, countY=3;
+      var lvl=1, goal=15, countL=1, countM=2, countY=3;
       ${nextLevelCode}
     `, context);
 
     context.nextLevel();
-    const { lvl, goalCaught, countL, countM, countY } = context;
+    const { lvl, countL, countM, countY } = context;
     expect(lvl).toBe(2);
-    expect(goalCaught).toBe(0);
     expect(countL).toBe(0);
     expect(countM).toBe(0);
     expect(countY).toBe(0);


### PR DESCRIPTION
## Summary
- Remove `goalCaught` in favor of deriving remaining mice from Loki's catches
- Adjust save/load, initialization, and win condition logic to use `countL`
- Update overlap handlers and tests to reflect new progress tracking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7ad3c600832699c424f335efcb22