### PR TITLE
Add level-up checks and tests

### DIFF
--- a/game.js
+++ b/game.js
@@ -29,8 +29,18 @@
 
   const INITIAL_GOAL = 15;
     let state='menu',lvl=1,goal=INITIAL_GOAL;
-    let countL=0,countM=0,countY=0,xp=0;
+    let countL=0,countM=0,countY=0,xp=0,xpLvl=1,xpTarget=5,canDash=false;
     function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-countL); xpEl.textContent=xp; }
+
+  function checkLevelUp(){
+    if(xp >= xpTarget){
+      xp -= xpTarget;
+      xpLvl++;
+      xpTarget = Math.ceil(xpTarget * 1.5);
+      if(!canDash && xpLvl >= 2) canDash = true;
+      if(loki) loki.speed += 50;
+    }
+  }
 
   function safeStorageGet(key, fallback=null){ try { return localStorage.getItem(key) ?? fallback; } catch { return fallback; } }
   function safeStorageSet(key, value){ try { localStorage.setItem(key, value); } catch { } }
@@ -243,7 +253,7 @@
     for (let i = 0; i < maxMice(); i++) spawnMouse();
 
     scene.physics.add.collider(loki, obstGroup);
-    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkEnd(); });
+    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkLevelUp(); checkEnd(); });
 
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
   }

--- a/game.test.js
+++ b/game.test.js
@@ -155,3 +155,36 @@ describe('minimap toggle', () => {
     expect(context.mm.style.display).toBe('none');
   });
 });
+
+describe('checkLevelUp', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+  const start = code.indexOf('function checkLevelUp');
+  const end = code.indexOf('function safeStorageGet', start);
+  const checkLevelUpCode = code.slice(start, end);
+
+  test('xp below target does not level up; xp meeting target does', () => {
+    const context = { xp: 4, xpTarget: 5, xpLvl: 1, canDash: false, loki: { speed: 100 } };
+    vm.createContext(context);
+    vm.runInContext(`${checkLevelUpCode}`, context);
+
+    context.checkLevelUp();
+    expect(context.xpLvl).toBe(1);
+    expect(context.xp).toBe(4);
+    expect(context.canDash).toBe(false);
+
+    context.xp = 5;
+    context.checkLevelUp();
+    expect(context.xpLvl).toBe(2);
+    expect(context.xp).toBe(0);
+    expect(context.canDash).toBe(true);
+  });
+
+  test('level up increases speed', () => {
+    const context = { xp: 5, xpTarget: 5, xpLvl: 1, canDash: false, loki: { speed: 100 } };
+    vm.createContext(context);
+    vm.runInContext(`${checkLevelUpCode}`, context);
+
+    context.checkLevelUp();
+    expect(context.loki.speed).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Track XP, level targets and dash unlocking
- Add checkLevelUp to increment XP level, adjust speed and reduce XP
- Cover leveling behavior with new Jest tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8356017483269b08ba651363b3fd