### PR TITLE
Enable menu buttons before Phaser scene ready

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,6 +56,8 @@
     btnNext.onclick = () => { ovWin.style.display='none'; nextLevel(); scene.scene.resume(); };
     btnRetry.onclick = () => { ovLose.style.display='none'; newGame(); startGame(); scene.scene.resume(); };
 
+    btnNew.disabled = btnContinue.disabled = false;
+
     const ensureTouchClick = btn => btn.addEventListener('touchend', () => btn.click());
     ensureTouchClick(btnNew);
     ensureTouchClick(btnContinue);

--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
 
 <div class="menu" id="menu"><div class="panel">
   <h1>🐱 Loki – Mäusejagd <small>v10.6 (Phaser) alpha</small></h1>
-  <button class="btn" id="btnContinue" style="display:none" disabled>Fortsetzen</button>
-  <button class="btn" id="btnNew" disabled>Neues Spiel</button>
+  <button class="btn" id="btnContinue" style="display:none">Fortsetzen</button>
+  <button class="btn" id="btnNew">Neues Spiel</button>
   <button class="btn" id="btnSettings">Einstellungen</button>
   <button class="btn" id="btnCredits">Credits</button>
   <div id="settings" style="display:none; margin-top:8px">


### PR DESCRIPTION
## Summary
- Remove `disabled` attributes from New and Continue buttons
- Activate menu buttons as soon as the menu initializes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8a1288a083269de0406fe90bf137