### PR TITLE
Handle asset load errors

### DIFF
--- a/game.js
+++ b/game.js
@@ -98,6 +98,19 @@
 
   function preload(){
     scene=this;
+    this.load.on('loaderror', (file) => {
+      console.error('Asset failed:', file.src);
+      loadMsg.textContent = 'Asset fehlgeschlagen: ' + file.key;
+      loadMsg.style.color = 'var(--bad)';
+      btnNew.disabled = btnContinue.disabled = true;
+    });
+    this.load.on('complete', () => {
+      if (!gameReady) {
+        gameReady = true;
+        btnNew.disabled = btnContinue.disabled = false;
+        loadMsg.textContent = '';
+      }
+    });
     for(const b of biomes){
       // Use the existing single background image for all parallax layers
       this.load.image(b, `${b}.webp`);


### PR DESCRIPTION
## Summary
- Add loader events in `preload` to surface asset load failures and disable game start when assets fail to load
- Mark game as ready after loading completes to cover cases where `create` is not invoked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b93b501f08326a9286aade4472cb3