### PR TITLE
Disable game menu buttons until assets load

### DIFF
--- a/game.js
+++ b/game.js
@@ -15,6 +15,7 @@
     const cL=document.getElementById('cL'), cM=document.getElementById('cM'), cY=document.getElementById('cY'), xpEl=document.getElementById('xp'), xpLvlEl=document.getElementById('xpLvl');
     const lvlEl = document.getElementById('lvl'), goalNeed = document.getElementById('goalNeed'), goalLeft = document.getElementById('goalLeft');
   const btnNew = document.getElementById('btnNew'), btnContinue = document.getElementById('btnContinue');
+  btnNew.disabled = btnContinue.disabled = true;
   const loadMsg = document.createElement('div');
   loadMsg.id = 'loadMsg';
   loadMsg.style.marginTop = '8px';
@@ -156,7 +157,7 @@
   } catch(err) {
     console.error('Game setup failed', err);
     gameReady = false;
-    btnNew.disabled = btnContinue.disabled = false;
+    btnNew.disabled = btnContinue.disabled = true;
     loadMsg.style.color = 'var(--bad)';
     loadMsg.textContent = 'Error loading assets. Please reload the page to try again.';
   }


### PR DESCRIPTION
## Summary
- Disable New and Continue buttons until assets are ready
- Re-enable buttons on successful game setup and keep disabled on errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b93b5a7fc8326af44601e603c2699