### PR TITLE
Always load WebP assets

### DIFF
--- a/game.js
+++ b/game.js
@@ -11,16 +11,10 @@
     3:[[600,600,600,100],[1700,900,500,90],[2600,700,420,90],[3400,1200,480,100]]
   };
 
-  const supportsWebP = (() => {
-    try {
-      return document
-        .createElement('canvas')
-        .toDataURL('image/webp')
-        .startsWith('data:image/webp');
-    } catch {
-      return false;
-    }
-  })();
+  // Assets are only provided in WebP format. Feature detection can incorrectly
+  // report lack of support on some browsers, leaving the game without required
+  // assets. Assume WebP support so the correct files are always requested.
+  const supportsWebP = true;
 
   const hud = document.getElementById('hud'), menu = document.getElementById('menu');
     const cL=document.getElementById('cL'), cM=document.getElementById('cM'), cY=document.getElementById('cY'), xpEl=document.getElementById('xp'), xpLvlEl=document.getElementById('xpLvl');
@@ -110,7 +104,8 @@
 
   function preload(){
     scene=this;
-    const ext = supportsWebP ? 'webp' : 'png';
+    // Only WebP assets are bundled; always request WebP files.
+    const ext = 'webp';
     for(const b of biomes){
       // Use the existing single background image for all parallax layers
       this.load.image(b, `${b}.${ext}`);

--- a/game.test.js
+++ b/game.test.js
@@ -155,3 +155,16 @@ describe('minimap toggle', () => {
     expect(context.mm.style.display).toBe('none');
   });
 });
+
+describe('asset loading format', () => {
+  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+
+  test('preload always requests webp assets', () => {
+    expect(code).toMatch(/const ext = 'webp';/);
+    expect(code).not.toMatch(/\.png/);
+  });
+
+  test('supportsWebP is hardcoded to true', () => {
+    expect(code).toMatch(/const supportsWebP = true;/);
+  });
+});


### PR DESCRIPTION
## Summary
- Assume WebP support and remove runtime detection
- Always request WebP files in preload to avoid missing asset errors
- Add tests to ensure only WebP assets are referenced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b98f337dc8326825b132d6db9e2f6