### PR TITLE
Add Phaser menu scene before main game

### DIFF
--- a/game.js
+++ b/game.js
@@ -82,6 +82,32 @@
   initMenu();
   applyLevelUp();
 
+  class MenuScene extends Phaser.Scene {
+    constructor() {
+      super('MenuScene');
+    }
+    preload() {
+      const ext = 'webp';
+      this.load.image('menu_bg', `street.${ext}`);
+      this.load.spritesheet('loki', `loki_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+      this.load.spritesheet('yumi', `yumi_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+      this.load.spritesheet('merlin', `merlin_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+    }
+    create() {
+      this.add.image(0, 0, 'menu_bg').setOrigin(0, 0);
+      const btn = this.add.text(this.scale.width / 2, this.scale.height / 2, 'Neues Spiel', {
+        fontSize: '32px',
+        color: '#fff'
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+      btn.on('pointerdown', () => {
+        startGame();
+        this.scene.start('MainScene');
+      });
+    }
+  }
+
+  const MainScene = { key: 'MainScene', preload, create, update };
+
   const config = {
     type: Phaser.AUTO,
     parent: 'game',
@@ -93,7 +119,7 @@
       height: 720
     },
     physics: { default: 'arcade', arcade: { gravity: { y: 0 }, debug: false } },
-    scene: { preload, create, update }
+    scene: [MenuScene, MainScene]
   };
   const game = new Phaser.Game(config);
   let scene, layers=null, loki, merlin=null, yumi=null, miceGroup, obstGroup;


### PR DESCRIPTION
## Summary
- Introduce MenuScene that preloads key sprites and background and shows a "Neues Spiel" button
- Configure Phaser to start with MenuScene and switch to MainScene on button click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b9b446fec8326bcd73d8cc8054812