### PR TITLE
feat: add Boot scene for asset preloading

### DIFF
--- a/BootScene.js
+++ b/BootScene.js
@@ -1,0 +1,39 @@
+class BootScene extends Phaser.Scene {
+  constructor() {
+    super('BootScene');
+  }
+
+  preload() {
+    this.load.on('progress', v => {
+      loadMsg.textContent = `Loading ${Math.round(v * 100)}%`;
+    });
+    this.load.on('loaderror', file => {
+      console.error('Failed to load', file.key);
+      loadMsg.style.color = 'var(--bad)';
+      loadMsg.textContent = `Error loading asset: ${file.key}`;
+      loadFailed = true;
+    });
+    this.load.on('complete', () => {
+      if (!loadFailed) {
+        gameReady = true;
+        btnNew.disabled = btnContinue.disabled = false;
+        loadMsg.textContent = '';
+      }
+      this.scene.start('MenuScene');
+    });
+
+    const ext = 'webp';
+    for (const b of biomes) {
+      this.load.image(b, `${b}.${ext}`);
+    }
+    this.load.image('menu_bg', `street.${ext}`);
+    this.load.spritesheet('loki', `loki_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('merlin', `merlin_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('yumi', `yumi_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
+    this.load.spritesheet('mouse', `mouse_sheet.${ext}`, { frameWidth: 56, frameHeight: 36 });
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = BootScene;
+}

--- a/game.js
+++ b/game.js
@@ -86,13 +86,6 @@
     constructor() {
       super('MenuScene');
     }
-    preload() {
-      const ext = 'webp';
-      this.load.image('menu_bg', `street.${ext}`);
-      this.load.spritesheet('loki', `loki_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-      this.load.spritesheet('yumi', `yumi_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-      this.load.spritesheet('merlin', `merlin_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-    }
     create() {
       this.add.image(0, 0, 'menu_bg').setOrigin(0, 0);
       const btn = this.add.text(this.scale.width / 2, this.scale.height / 2, 'Neues Spiel', {
@@ -106,7 +99,7 @@
     }
   }
 
-  const MainScene = { key: 'MainScene', preload, create, update };
+  const MainScene = { key: 'MainScene', create, update };
 
   const config = {
     type: Phaser.AUTO,
@@ -119,7 +112,7 @@
       height: 720
     },
     physics: { default: 'arcade', arcade: { gravity: { y: 0 }, debug: false } },
-    scene: [MenuScene, MainScene]
+    scene: [BootScene, MenuScene, MainScene]
   };
   const game = new Phaser.Game(config);
   let scene, layers=null, loki, merlin=null, yumi=null, miceGroup, obstGroup;
@@ -128,39 +121,8 @@
   const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?80:100;
   const maxMice = () => Math.floor(BASE_MICE * (1 + 0.5*(lvl-1)));
 
-  function preload(){
-    scene=this;
-
-    scene.load.on('progress', v => {
-      loadMsg.textContent = `Loading ${Math.round(v*100)}%`;
-    });
-    scene.load.on('loaderror', file => {
-      console.error('Failed to load', file.key);
-      loadMsg.style.color = 'var(--bad)';
-      loadMsg.textContent = `Error loading asset: ${file.key}`;
-      loadFailed = true;
-    });
-    scene.load.on('complete', () => {
-      if (!loadFailed) {
-        gameReady = true;
-        btnNew.disabled = btnContinue.disabled = false;
-        loadMsg.textContent = '';
-      }
-    });
-
-    // Only WebP assets are bundled; always request WebP files.
-    const ext = 'webp';
-    for(const b of biomes){
-      // Use the existing single background image for all parallax layers
-      this.load.image(b, `${b}.${ext}`);
-    }
-    this.load.spritesheet('loki', `loki_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('merlin', `merlin_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('yumi', `yumi_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
-    this.load.spritesheet('mouse', `mouse_sheet.${ext}`, { frameWidth: 56, frameHeight: 36 });
-  }
-
   function create(){
+    scene=this;
     if (this.scale.lockOrientation) {
       this.scale.lockOrientation('landscape');
     }

--- a/game.test.js
+++ b/game.test.js
@@ -157,14 +157,15 @@ describe('minimap toggle', () => {
 });
 
 describe('asset loading format', () => {
-  const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
+  const bootCode = fs.readFileSync(__dirname + '/BootScene.js', 'utf8');
+  const gameCode = fs.readFileSync(__dirname + '/game.js', 'utf8');
 
   test('preload always requests webp assets', () => {
-    expect(code).toMatch(/const ext = 'webp';/);
-    expect(code).not.toMatch(/\.png/);
+    expect(bootCode).toMatch(/const ext = 'webp';/);
+    expect(bootCode).not.toMatch(/\.png/);
   });
 
   test('supportsWebP is hardcoded to true', () => {
-    expect(code).toMatch(/const supportsWebP = true;/);
+    expect(gameCode).toMatch(/const supportsWebP = true;/);
   });
 });

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@ if(!window.Phaser){
   document.body.insertAdjacentHTML('beforeend','<div style="color:red;position:fixed;top:0;left:0;">Phaser konnte nicht geladen werden.</div>');
 }
 </script>
+<script src="BootScene.js"></script>
 <script src="MenuScene.js"></script>
 <script src="game.js?v=107"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- add BootScene to preload all assets and update loading message
- start BootScene before menu and transfer asset load progress there
- adjust tests for new BootScene asset loader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b9eca71348326a670a94328e91a9c