### PR TITLE
Expose BootScene variables on window and sync load state

### DIFF
--- a/game.js
+++ b/game.js
@@ -38,6 +38,15 @@
   const skillbar = document.querySelector('.skillbar');
   const btnSprint = document.getElementById('btnSprint');
   let gameReady = false, loadFailed = false;
+  Object.assign(window, { biomes, META, loadMsg, btnNew, btnContinue });
+  Object.defineProperty(window, 'gameReady', {
+    get: () => gameReady,
+    set: v => { gameReady = v; }
+  });
+  Object.defineProperty(window, 'loadFailed', {
+    get: () => loadFailed,
+    set: v => { loadFailed = v; }
+  });
   if (!gameReady) {
     console.log('Loading assets...');
     loadMsg.textContent = 'Loading 0%';


### PR DESCRIPTION
## Summary
- Share BootScene dependencies (biomes, META, DOM references) by attaching them to `window`.
- Add `gameReady` and `loadFailed` properties on `window` with getters/setters to keep state synchronized.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba193a3348326abe9dbb1ef69dd84