### PR TITLE
Reuse street texture for menu background

### DIFF
--- a/BootScene.js
+++ b/BootScene.js
@@ -24,9 +24,10 @@ class BootScene extends Phaser.Scene {
 
     const ext = 'webp';
     for (const b of biomes) {
-      this.load.image(b, `${b}.${ext}`);
+      if (!this.textures.exists(b)) {
+        this.load.image(b, `${b}.${ext}`);
+      }
     }
-    this.load.image('menu_bg', `street.${ext}`);
     this.load.spritesheet('loki', `loki_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
     this.load.spritesheet('merlin', `merlin_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });
     this.load.spritesheet('yumi', `yumi_sheet.${ext}`, { frameWidth: META.w, frameHeight: META.h });

--- a/game.js
+++ b/game.js
@@ -87,7 +87,7 @@
       super('MenuScene');
     }
     create() {
-      this.add.image(0, 0, 'menu_bg').setOrigin(0, 0);
+      this.add.image(0, 0, 'street').setOrigin(0, 0);
       const btn = this.add.text(this.scale.width / 2, this.scale.height / 2, 'Neues Spiel', {
         fontSize: '32px',
         color: '#fff'


### PR DESCRIPTION
## Summary
- Avoid reloading already cached biome textures in `BootScene`
- Use existing `street` texture as menu background instead of `menu_bg`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba1a590408326a307f7b3c36f8933