### PR TITLE
Handle missing Phaser before game setup

### DIFF
--- a/game.js
+++ b/game.js
@@ -109,6 +109,10 @@
   }
 
   const MainScene = { key: 'MainScene', create, update };
+  if (!window.Phaser) {
+    loadMsg.textContent = 'Phaser nicht verfügbar';
+    return;
+  }
 
   const config = {
     type: Phaser.AUTO,


### PR DESCRIPTION
## Summary
- Prevent game initialization when `window.Phaser` is unavailable and show an error message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba7a26a348326881e32c3806d015f