### PR TITLE
Fix asset diagnostic paths for Merlin, Yumi, and mouse

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,9 @@
 const assetOverrides = {};
 const checks = {
   loki: ['loki_bkh_sheet.webp','loki_sheet.webp','sprites_loki.webp'],
-  merlin: ['merlin_bkh_sheet_v3.webp','merlin_bkh_sheet.webp','sprites_merlin.webp'],
-  yumi: ['yumi_bkh_sheet.webp','sprites_yumi.webp'],
-  mouse: ['mouse_gold.webp','sprites_mouse.webp'],
+  merlin: ['merlin_bkh_sheet_v3.webp','merlin_bkh_sheet.webp','merlin_sheet.webp','sprites_merlin.webp'],
+  yumi: ['yumi_bkh_sheet.webp','yumi_sheet.webp','sprites_yumi.webp'],
+  mouse: ['mouse_gold.webp','mouse_sheet.webp','sprites_mouse.webp'],
   bgm: ['bgm.wav','bgm.mp3','music.mp3']
 };
 async function runDiagnostics(){


### PR DESCRIPTION
## Summary
- Check for default `merlin_sheet.webp`, `yumi_sheet.webp`, and `mouse_sheet.webp` during asset diagnostics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb01338588326ac0141a95a89c20e